### PR TITLE
Solution for Issue User Stories

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -9,9 +9,13 @@ class PeopleController < ApplicationController
   end
 
   def create
-    Person.create!(person_attributes)
+    @person = Person.new(person_attributes)
     
-    redirect_to people_path, notice: 'Successfully created entry'
+    if @person.save
+      redirect_to people_path, notice: 'Successfully created entry'
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -12,6 +12,7 @@
 #
 
 class Person < ApplicationRecord
+  validates :name, presence: true
   
   belongs_to :company, optional: true
 end

--- a/app/views/people/new.html.slim
+++ b/app/views/people/new.html.slim
@@ -1,5 +1,14 @@
 h2 Creating an entry
 
+- if @person.errors.any?
+  .alert.alert-danger
+    h3
+      | Validation errors:
+    ul
+      - @person.errors.full_messages.each do |message|
+        li
+          = message
+          
 = form_for @person, class: 'row' do |f|
   .col-auto
     = f.label :name, class: 'form-label'

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PeopleController, type: :controller do
     it { is_expected.to have_http_status(:ok) }
   end
 
-  describe 'POST create' do
+  describe 'POST create with valid params' do
     it 'Creates a record' do
       expect{ post :create, params: { person: { name: 'foo', phone_number: '123', email: 'foo' } } }.to change{ Person.count }.by(1)
     end
@@ -22,5 +22,13 @@ RSpec.describe PeopleController, type: :controller do
     it 'has status found' do
       expect(post :create, params: { person: { name: 'foo', phone_number: '123', email: 'foo' } }).to have_http_status(:found)
     end
+  end
+
+  describe 'POST create with invalid params' do
+    before do
+      post :create, params: { person: { phone_number: '123', email: 'foo' } }
+    end
+    
+    it { is_expected.to have_http_status(:unprocessable_entity) }
   end
 end


### PR DESCRIPTION
## Task

As a front-end user, when creating a new Person entry, when the new entry is unable to be saved, I will see a message with the error, and it will keep the values in the fields I have already filled out.

## Solution

1. If there is an error when saving the person record, display an error message. Update the people controller to return an error message.
2. Since there is no validation for the persons mentioned in this task, I added a validation for the name field so that we can check whether the error message is displayed or not.
3. Update tests



